### PR TITLE
Load client ID from config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ windsurf-workspace.json
 .tern-port
 .vscode-test/
 
+.env/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # photosort
 
-initial README.md
+This repository contains a simple test page that lists Google Photos
+albums. The OAuth *client ID* used by the page is loaded from a separate
+configuration file so that your real credentials can stay outside of the
+repository.
+
+## Setup
+
+1. Copy `client_config.js.example` to `.env/client_config.js`.
+2. Edit `.env/client_config.js` and replace the placeholder with your own
+   Google OAuth client ID.
+3. Open `google_photos_test.html` in your browser.
+
+The `.env` directory is ignored by Git, keeping your private client ID
+out of version control.

--- a/client_config.js.example
+++ b/client_config.js.example
@@ -1,0 +1,3 @@
+// Replace the placeholder with your Google OAuth Client ID.
+// Copy this file to `.env/client_config.js` and edit the value below.
+const CLIENT_ID = 'YOUR_CLIENT_ID_HERE';

--- a/google_photos_test.html
+++ b/google_photos_test.html
@@ -14,8 +14,8 @@
   <button id="signout_button" style="display:none">Sign Out</button>
   <ul id="albums"></ul>
 
+  <script src=".env/client_config.js"></script>
   <script>
-    const CLIENT_ID = 'YOUR_CLIENT_ID_HERE';
     const SCOPES = 'https://www.googleapis.com/auth/photoslibrary.readonly';
 
     function initClient() {


### PR DESCRIPTION
## Summary
- load the OAuth client ID from `.env/client_config.js`
- provide `client_config.js.example` with placeholder instructions
- document config file usage in README
- ignore `.env/` in git

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68467a0ceb40832d902671aec89fac42